### PR TITLE
hotfix-front pagination and shelter filter

### DIFF
--- a/Client/my-app/src/App/components/Cards/CardsContainer.jsx
+++ b/Client/my-app/src/App/components/Cards/CardsContainer.jsx
@@ -18,6 +18,7 @@ function ContenedorCard({ className, title, petPosted, petFiltered }) {
 
   useEffect(() => {
     dispatch(title === 'ADOPCIONES' ? getPetsAdop() : title === 'PERDIDOS' ? getLostPets() : getShelters());
+    setCurrentPage(1);
   }, [dispatch, title, petPosted]);
 
   useEffect(() => {
@@ -118,7 +119,7 @@ function ContenedorCard({ className, title, petPosted, petFiltered }) {
           })
         ) : (
           <div className='w-full h-full col-span-3 flex flex-col items-center mt-8'>
-            <h2 className='text-3xl font-bold text-primaryDark'>No se encontraron mascotas con esos parámetros</h2>
+            <h2 className='text-3xl font-bold text-primaryDark'>No se encontraron {title === 'REFUGIOS' ? 'refugios' : 'mascotas'} con esos parámetros</h2>
             <img src={'https://i.pinimg.com/originals/18/0d/95/180d95834d68ad0add738b765a82c97a.gif'} alt='' className='h-96 w-100 mt-4' />
           </div>
         )}

--- a/Client/my-app/src/App/components/FilterBar/FiltersBar.jsx
+++ b/Client/my-app/src/App/components/FilterBar/FiltersBar.jsx
@@ -153,7 +153,7 @@ function FiltersBar({ onFilterPet }) {
     cleanFilter.city === '' && delete cleanFilter.city;
     cleanFilter.province === '' && delete cleanFilter.province;
 
-    onFilterPet();
+    onFilterPet && onFilterPet();
 
     currentLocation === '/adopciones'
       ? dispatch(getPetsAdopFilter(cleanFilter))

--- a/Client/my-app/src/App/components/pop-up/ContactoPerdido.jsx
+++ b/Client/my-app/src/App/components/pop-up/ContactoPerdido.jsx
@@ -6,7 +6,7 @@ import { getUserById } from '../../services/getUserById';
 import { IoIosCloseCircle } from 'react-icons/io';
 import { FaWhatsapp, FaMailBulk } from 'react-icons/fa';
 
-function ContactoPerdido({ onClose, name, petId, userId }) {
+function ContactoPerdido({ onClose, name, userId }) {
   const [user, setUser] = useState({ id: '', name: '' });
   const [owner, setOwner] = useState([]);
 


### PR DESCRIPTION
Paginación vuelve a página 1 cuando pasás de Perdidos a Adopciones.

Filtrar por ubicación en Refugios no rompe con onPetFilter.